### PR TITLE
intoduce optional

### DIFF
--- a/shlex.h
+++ b/shlex.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <string>
+#include <stdexcept>
 
 namespace shlex
 {

--- a/shlex.h
+++ b/shlex.h
@@ -1,10 +1,108 @@
 #ifndef SHOGO82148_SHLEX_H_
 #define SHOGO82148_SHLEX_H_
 
+#include <vector>
 #include <string>
 
 namespace shlex
 {
+  // simple backport of std::optional
+  template <typename T>
+  class optional
+  {
+  private:
+    bool has_value_;
+    T value_;
+
+  public:
+    typedef T value_type;
+
+    struct nullopt_t
+    {
+      explicit nullopt_t() {}
+    };
+    static const nullopt_t nullopt;
+
+    // default constructor
+    optional() : has_value_(false), value_() {}
+    optional(nullopt_t) : has_value_(false), value_() {}
+
+    // copy constructor
+    optional(const optional &other) : has_value_(other.has_value_), value_(other.value_) {}
+
+    // constructor with value
+    optional(const T &value) : has_value_(true), value_(value) {}
+
+    // destructor
+    ~optional() {}
+
+    // copy assignment operator
+    optional &operator=(const optional &other)
+    {
+      if (this != &other)
+      {
+        has_value_ = other.has_value_;
+        value_ = other.value_;
+      }
+      return *this;
+    }
+
+    // nullopt assignment operator
+    optional &operator=(nullopt_t)
+    {
+      has_value_ = false;
+      value_ = T();
+      return *this;
+    }
+
+    // value assignment operator
+    optional &operator=(const T &value)
+    {
+      has_value_ = true;
+      value_ = value;
+      return *this;
+    }
+
+    // returns true if the optional has a value
+    bool has_value() const
+    {
+      return has_value_;
+    }
+    operator bool() const
+    {
+      return has_value_;
+    }
+
+    // returns the value if the optional has a value, otherwise throws an exception
+    T &value()
+    {
+      if (!has_value_)
+      {
+        throw std::runtime_error("optional does not have a value");
+      }
+      return value_;
+    }
+    const T &value() const
+    {
+      if (!has_value_)
+      {
+        throw std::runtime_error("optional does not have a value");
+      }
+      return value_;
+    }
+    T &operator*()
+    {
+      return value();
+    }
+    const T &operator*() const
+    {
+      return value();
+    }
+  };
+
+  template <typename T>
+  const typename optional<T>::nullopt_t optional<T>::nullopt = optional<T>::nullopt_t();
+
   // returns a shell-escaped version of the string s
   std::string quote(const std::string &s);
 }

--- a/test.cpp
+++ b/test.cpp
@@ -35,6 +35,54 @@ static void is(const std::string &a, const std::string &b, const char *msg)
   }
 }
 
+static void is(int a, int b, const char *msg)
+{
+  testCount++;
+  if (a == b)
+  {
+    std::cout << "ok " << testCount << " - " << msg << std::endl;
+  }
+  else
+  {
+    ngCount++;
+    std::cout << "not ok " << testCount << " - " << msg << std::endl
+              << "# Expected: " << b << std::endl
+              << "#   Actual: " << a << std::endl;
+  }
+}
+
+static void testOptional(void)
+{
+  shlex::optional<int> a;
+  ok(!a, "optional<int> default constructor");
+
+  shlex::optional<int> b(shlex::optional<int>::nullopt);
+  ok(!b, "optional<int> nullopt constructor");
+
+  shlex::optional<int> c(42);
+  ok(c, "optional<int> value constructor");
+  is(c.value(), 42, "optional<int> value constructor");
+  is(*c, 42, "optional<int> value constructor");
+
+  shlex::optional<int> d(c);
+  ok(d, "optional<int> copy constructor");
+  is(d.value(), 42, "optional<int> copy constructor");
+
+  shlex::optional<int> e;
+  e = c;
+  ok(e, "optional<int> copy assignment operator");
+  is(e.value(), 42, "optional<int> copy assignment operator");
+
+  shlex::optional<int> f;
+  f = shlex::optional<int>::nullopt;
+  ok(!f, "optional<int> nullopt assignment operator");
+
+  shlex::optional<int> g;
+  g = 42;
+  ok(g, "optional<int> value assignment operator");
+  is(g.value(), 42, "optional<int> value assignment operator");
+}
+
 static void testQuote(void)
 {
   is(shlex::quote(""), "''", "quote empty string");
@@ -65,6 +113,7 @@ static void testQuote(void)
 
 int main(void)
 {
+  testOptional();
   testQuote();
 
   std::cout << "1.." << testCount << std::endl;


### PR DESCRIPTION
I want to use `std::optional` while it is available from C++17.
My target environment is C++11 or earlier, so `std::optional` is not available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new mechanism for handling optional values, increasing safety and flexibility in value management.
- **Tests**
	- Expanded testing capabilities with new integer comparison functionality and comprehensive tests for the optional value management, ensuring robust functionality and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->